### PR TITLE
Anycc 44 check if first has epsilon

### DIFF
--- a/src/Parser/FirstAndFollowGenerator.cpp
+++ b/src/Parser/FirstAndFollowGenerator.cpp
@@ -150,7 +150,7 @@ std::set<std::string> FirstAndFollowGenerator::computeFollow(const std::string &
                             //   then FOLLOW(B) contains { FIRST(q) – Є } U FOLLOW(A)
                             qIndex--;
                             if (qIndex < production.size() &&
-                                (computedFirstSetsWithoutProductions[production[qIndex]].find(EPSILON) ==
+                                (computedFirstSetsWithoutProductions[production[qIndex]].find(EPSILON) !=
                                  computedFirstSetsWithoutProductions[production[qIndex]].end()
                                  || nonTerminalHasEpsilon(production[qIndex]))) {
                                 const std::set<std::string> &followASet = computeFollow(rule.nonTerminal);


### PR DESCRIPTION
## Bug Fixed
- Condition Typo when checking if First(q) has epsilon or not. 
`If A->pBq is a production and FIRST(q) contains Є,`